### PR TITLE
Feature/parse json

### DIFF
--- a/src/kixi/ckan/data.clj
+++ b/src/kixi/ckan/data.clj
@@ -6,11 +6,21 @@
             [clj-http.client       :as client]
             [clojure.tools.logging :as log]))
 
+(defn fix-map-key
+  "Takes string keys and format them before they
+  get turned into keywords."
+  [keys-string]
+  (-> keys-string
+      (clojure.string/lower-case)
+      (clojure.string/replace #"[ \n]" "_")
+      (clojure.string/replace #"[^A-Za-z0-9-_]" "")))
+
 (defn unparse
   "Takes DataStore data represented as JSON and turns it to clojure data structure."
   [data]
   (let [data-edn (-> data
-                     (json/parse-string true)
+                     (json/parse-string
+                      (fn [k] (keyword (fix-map-key k))))
                      (get :result))]
     (->> (apply concat data-edn)
          (apply hash-map))))

--- a/src/kixi/ckan/data.clj
+++ b/src/kixi/ckan/data.clj
@@ -53,7 +53,5 @@
         next-page (+ offset 100)]
      (lazy-cat
       (get unparsed :records)
-      (try
-        (when (< next-page total)
-          (page-results site-url resource_id next-page))
-        (catch Exception e (.getMessage e) (println "Help, an exception!"))))))
+      (when (< next-page total)
+        (page-results site-url resource_id next-page)))))

--- a/src/kixi/ckan/data.clj
+++ b/src/kixi/ckan/data.clj
@@ -10,8 +10,8 @@
   "Takes DataStore data represented as JSON and turns it to clojure data structure."
   [data]
   (let [data-edn (-> data
-                     (json/parse-string)
-                     (get "result"))]
+                     (json/parse-string true)
+                     (get :result))]
     (->> (apply concat data-edn)
          (apply hash-map))))
 
@@ -39,8 +39,11 @@
   (let [url       (str "http://" site-url "datastore_search?offset=" offset "&resource_id=" resource_id)
         result    (client/get url {:content-type :json :accept :json})
         unparsed  (-> result :body unparse)
-        total     (get unparsed "total")
+        total     (get unparsed :total)
         next-page (+ offset 100)]
      (lazy-cat
-      (get unparsed "records")
-      (when (< next-page total) (page-results site-url resource_id next-page)))))
+      (get unparsed :records)
+      (try
+        (when (< next-page total)
+          (page-results site-url resource_id next-page))
+        (catch Exception e (.getMessage e) (println "Help, an exception!"))))))

--- a/src/kixi/ckan/data.clj
+++ b/src/kixi/ckan/data.clj
@@ -49,7 +49,7 @@
   (let [url       (str "http://" site-url "datastore_search?offset=" offset "&resource_id=" resource_id)
         result    (client/get url {:content-type :json :accept :json})
         unparsed  (-> result :body unparse)
-        total     (get unparsed :total)
+        total     (:total unparsed)
         next-page (+ offset 100)]
      (lazy-cat
       (get unparsed :records)

--- a/test/kixi/ckan/data_test.clj
+++ b/test/kixi/ckan/data_test.clj
@@ -2,16 +2,26 @@
   (:require [clojure.test :refer :all]
             [kixi.ckan.data :refer :all]))
 
+(deftest fix-map-key-test
+  (testing "The map keys are formatted correctly.")
+  (is (= "level_description"
+         (fix-map-key "Level description")))
+  (is (= "_id"
+         (fix-map-key "_id")))
+  (is (= "period_of_coverage"
+         (fix-map-key "Period of coverage")))
+  (is (= "notes_denominator_indicator_value"
+         (fix-map-key "Notes
+Denominator, indicator value")))
+  (is (= "indicator_value_rate"
+         (fix-map-key "Indicator value (rate)"))))
+
 (deftest unparse-test
-  (is (= {"records" [{"foo" "1.3"}
-                     {"bar" "1.3"}]
-          "fields" [{"type" "numeric" "id" "foo"}
-                    {"type" "numeric" "id" "bar"}]
-          "resource_id" "1"
-          "total" 2
-          "_links"
-          {"start" "/api/3/action/datastore_search?resource_id=1",
-           "next" "/api/3/action/datastore_search?offset=100&resource_id=1"}}
+  (is (= {:fields [{:type "numeric", :id "foo"} {:type "numeric", :id "bar"}],
+          :records [{:foo "1.3"} {:bar "1.3"}],
+          :total 2,
+          :_links {:start "/api/3/action/datastore_search?resource_id=1",
+                   :next "/api/3/action/datastore_search?offset=100&resource_id=1"}, :resource_id "1"}
          (unparse "{\"help\" : \"help\",
                    \"success\": true,
                    \"result\" : {\"total\" : 2,


### PR DESCRIPTION
Changes made while improving nhs board report: 
I added a function to customise the way we parse json with Cheshire.
It helps getting better formatted keywords map keys.

Notes:
1) It seems only (unparse-test) and (page-results) call (unparse).
2) Is it useful to do this formatting in kixi.ckan? Would it potentially be used for more projects than the NHS project?
